### PR TITLE
Use native events and event listeners instead of callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ react-native link react-native-p2pkit
 5. Setup and link the p2pkit framework on your native environments:
   * <strong>iOS</strong>: Follow the [CocoaPods setup](http://p2pkit.io/developer/get-started/ios/#signup)
 > Currently the module is configured to use CocoaPods for fetching and linking the P2PKit.framework. If you are getting "header search paths" errors, make sure to compile the Pods project at least once so that the p2pkit headers will be exported to ./Pods/Headers/Public, the module is configured to search for them there. Note that Bitcode is not supported, you would need to disable Bitcode in your iOS project.
-  
+
   * <strong>Android</strong>: Follow the [setup here](http://p2pkit.io/developer/get-started/android/)
 > Don't forget to add the p2pkit maven repository to your app's gradle file (as mentioned in the link above)
 
@@ -35,58 +35,71 @@ Here is an example that implements p2pkit functionality. Begin by calling <code>
 ```
 import p2pkit from 'react-native-p2pkit';
 
-var p2pkitCallback = {
+class MyComponent extends Component {
+  onException = (exceptionMessage) => {
+    console.log(exceptionMessage.message)
+  }
 
-    onException: function(exceptionMessage) {
-        console.log(exceptionMessage.message)
-    },
+  onEnabled = () => {
+    console.log('p2pkit is enabled')
+    p2pkit.enableProximityRanging()
+    p2pkit.startDiscovery('', p2pkit.HIGH_PERFORMANCE) //base64 encoded Data (bytes)
+  }
 
-    onEnabled: function() {
-        console.log('p2pkit is enabled')
-        p2pkit.enableProximityRanging()
-        p2pkit.startDiscovery('', p2pkit.HIGH_PERFORMANCE) //base64 encoded Data (bytes)
-    },
+  onDisabled = () => {
+    console.log('p2pkit is disabled')
+  }
 
-    onDisabled: function() {
-        console.log('p2pkit is disabled')
-    },
+  // Refer to platform specific API for error codes
+  onError = (errorObject) => {
+    console.log('p2pkit failed to enable on platform ' + errorObject.platform + ' with error code ' + errorObject.errorCode)
+  }
 
-    // Refer to platform specific API for error codes
-    onError: function(errorObject) {
-        console.log('p2pkit failed to enable on platform ' + errorObject.platform + ' with error code ' + errorObject.errorCode)
-    },
+  onDiscoveryStateChanged = (discoveryStateObject) => {
+    console.log('discovery state updated on platform ' + discoveryStateObject.platform + ' with error code ' + discoveryStateObject.state)
+  }
 
-    onDiscoveryStateChanged: function(discoveryStateObject) {
-        console.log('discovery state updated on platform ' + discoveryStateObject.platform + ' with error code ' + discoveryStateObject.state)
-    },
+  onPeerDiscovered = (peer) => {
+    console.log('peer discovered ' + peer.peerID)
+  }
 
-    onPeerDiscovered: function(peer) {
-        console.log('peer discovered ' + peer.peerID)
-    },
+  onPeerLost = (peer) => {
+    console.log('peer lost ' + peer.peerID)
+  }
 
-    onPeerLost: function(peer) {
-        console.log('peer lost ' + peer.peerID)
-    },
+  onPeerUpdatedDiscoveryInfo = (peer) => {
+    console.log('discovery info updated for peer ' + peer.peerID + ' info ' + peer.discoveryInfo)
+  }
 
-    onPeerUpdatedDiscoveryInfo: function(peer) {
-        console.log('discovery info updated for peer ' + peer.peerID + ' info ' + peer.discoveryInfo)
-    },
+  onProximityStrengthChanged = (peer) => {
+    console.log('proximity strength changed for peer ' + peer.peerID + ' proximity strength ' + peer.proximityStrength)
+  }
 
-    onProximityStrengthChanged: function(peer) {
-        console.log('proximity strength changed for peer ' + peer.peerID + ' proximity strength ' + peer.proximityStrength)
-    },
+  onGetMyPeerId = (reply) => {
+    console.log(reply.myPeerId)
+  }
 
-    onGetMyPeerId: function(reply) {
-        console.log(reply.myPeerId)
-    },
-    
-    onGetDiscoveryPowerMode: function(reply) {
-    	console.log(reply.discoveryPowerMode)
-    }
-}
+  onGetDiscoveryPowerMode = (reply) => {
+  console.log(reply.discoveryPowerMode)
+  }
 
-startP2PKit: function() {
-    p2pkit.enable('<YOUR APPLICATION KEY>', p2pkitCallback)
+  componentWillMount() {
+    p2pkit.addListener('onEnabled', this.onEnabled)
+    p2pkit.addListener('onPeerDiscovered', this.onPeerDiscovered)
+  }
+
+  componentWillUnmount() {
+    p2pkit.removeListener('onEnabled', this.onEnabled)
+    p2pkit.removeListener('onPeerDiscovered', this.onPeerDiscovered)
+  }
+
+  componentDidMount() {
+    p2pkit.enable('<YOUR APPLICATION KEY>')
+  }
+
+  render() {
+    // render code
+  }
 }
 ```
 

--- a/android/src/main/java/ch/uepaa/p2pkit/reactnative/PPKReactBridgeModule.java
+++ b/android/src/main/java/ch/uepaa/p2pkit/reactnative/PPKReactBridgeModule.java
@@ -264,12 +264,7 @@ public class PPKReactBridgeModule extends ReactContextBaseJavaModule implements 
             return;
         }
 
-        WritableMap moduleResponse = Arguments.createMap();
-
-        moduleResponse.putString("methodName",methodName);
-        if (params != null) moduleResponse.putMap("params",params);
-
-        mApplicationContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("callback", moduleResponse);
+        mApplicationContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(methodName, params);
     }
 
     private WritableMap createMapFromPeer(Peer peer) {

--- a/android/src/main/java/ch/uepaa/p2pkit/reactnative/PPKReactBridgeModule.java
+++ b/android/src/main/java/ch/uepaa/p2pkit/reactnative/PPKReactBridgeModule.java
@@ -253,7 +253,7 @@ public class PPKReactBridgeModule extends ReactContextBaseJavaModule implements 
         invokePluginResult("onException", map);
     }
 
-    private void invokePluginResult(String methodName, WritableMap parms) {
+    private void invokePluginResult(String methodName, WritableMap params) {
 
       if (mApplicationContext == null) {
           P2PKit.disable();
@@ -267,7 +267,7 @@ public class PPKReactBridgeModule extends ReactContextBaseJavaModule implements 
         WritableMap moduleResponse = Arguments.createMap();
 
         moduleResponse.putString("methodName",methodName);
-        if (parms != null) moduleResponse.putMap("parms",parms);
+        if (params != null) moduleResponse.putMap("params",params);
 
         mApplicationContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("callback", moduleResponse);
     }

--- a/index.js
+++ b/index.js
@@ -1,73 +1,70 @@
 /**
- * @providesModule P2PKit
- * @flow
- */
+* @providesModule P2PKit
+* @flow
+*/
 'use strict';
 
 import {
   NativeModules,
   NativeEventEmitter
- } from 'react-native';
+} from 'react-native';
 
 const { PPKReactBridge } = NativeModules;
 
 export default class P2PKit {
+  static LOW_POWER = 'LOW_POWER';
+  static HIGH_PERFORMANCE = 'HIGH_PERFORMANCE';
+  static p2pkitCallbackHandler_;
+  static p2pkitCallbackEmitter = new NativeEventEmitter(PPKReactBridge);
 
-	static LOW_POWER = 'LOW_POWER';
-	static HIGH_PERFORMANCE = 'HIGH_PERFORMANCE';
-	static p2pkitCallbackHandler_;
-	static p2pkitCallbackEmitter = new NativeEventEmitter(PPKReactBridge);
+  static subscription = P2PKit.p2pkitCallbackEmitter.addListener(
+    'callback',
+    (nativeCallback) => {
+      if (P2PKit.p2pkitCallbackHandler_[nativeCallback.methodName]) {
+        P2PKit.p2pkitCallbackHandler_[nativeCallback.methodName](nativeCallback.params);
+      }
+    }
+  )
 
-	static subscription = P2PKit.p2pkitCallbackEmitter.addListener(
-		'callback',
-    	(nativeCallback) => {
-      		if(P2PKit.p2pkitCallbackHandler_[nativeCallback.methodName]) {
-        		P2PKit.p2pkitCallbackHandler_[nativeCallback.methodName](nativeCallback.parms);
-      		}
-    	}
-  	)
-
-  	static enable(appkey, p2pkitCallbackHandler){
-
-		if(!p2pkitCallbackHandler){
-        throw 'You must enable p2pkit with appropriate callbacks';
+  static enable(appkey, p2pkitCallbackHandler) {
+    if (!p2pkitCallbackHandler) {
+      throw 'You must enable p2pkit with appropriate callbacks';
     }
 
     P2PKit.p2pkitCallbackHandler_ = p2pkitCallbackHandler;
 
-    	PPKReactBridge.enable(appkey);
-    }
+    PPKReactBridge.enable(appkey);
+  }
 
-	static disable(){
-      	PPKReactBridge.disable();
-    }
+  static disable(){
+    PPKReactBridge.disable();
+  }
 
-	static getMyPeerId(myPeerId){
-      	PPKReactBridge.getMyPeerId();
-    }
+  static getMyPeerId(myPeerId){
+    PPKReactBridge.getMyPeerId();
+  }
 
-	static startDiscovery(discoveryInfo, discoveryPowerMode){
-      	PPKReactBridge.startDiscovery(discoveryInfo, discoveryPowerMode);
-    }
+  static startDiscovery(discoveryInfo, discoveryPowerMode){
+    PPKReactBridge.startDiscovery(discoveryInfo, discoveryPowerMode);
+  }
 
-	static stopDiscovery(){
-      	PPKReactBridge.stopDiscovery();
-    }
+  static stopDiscovery(){
+    PPKReactBridge.stopDiscovery();
+  }
 
-	static enableProximityRanging(){
-      	PPKReactBridge.enableProximityRanging();
-    }
+  static enableProximityRanging(){
+    PPKReactBridge.enableProximityRanging();
+  }
 
-	static pushNewDiscoveryInfo(discoveryInfo){
-      	PPKReactBridge.pushNewDiscoveryInfo(discoveryInfo);
-    }
-    
-	static getDiscoveryPowerMode() {
-      	PPKReactBridge.getDiscoveryPowerMode();
-	}
-    
-	static setDiscoveryPowerMode(discoveryPowerMode) {
-      	PPKReactBridge.setDiscoveryPowerMode(discoveryPowerMode);
-	}
+  static pushNewDiscoveryInfo(discoveryInfo){
+    PPKReactBridge.pushNewDiscoveryInfo(discoveryInfo);
+  }
 
-};
+  static getDiscoveryPowerMode() {
+    PPKReactBridge.getDiscoveryPowerMode();
+  }
+
+  static setDiscoveryPowerMode(discoveryPowerMode) {
+    PPKReactBridge.setDiscoveryPowerMode(discoveryPowerMode);
+  }
+}

--- a/index.js
+++ b/index.js
@@ -14,49 +14,41 @@ const { PPKReactBridge } = NativeModules;
 export default class P2PKit {
   static LOW_POWER = 'LOW_POWER';
   static HIGH_PERFORMANCE = 'HIGH_PERFORMANCE';
-  static p2pkitCallbackHandler_;
   static p2pkitCallbackEmitter = new NativeEventEmitter(PPKReactBridge);
 
-  static subscription = P2PKit.p2pkitCallbackEmitter.addListener(
-    'callback',
-    (nativeCallback) => {
-      if (P2PKit.p2pkitCallbackHandler_[nativeCallback.methodName]) {
-        P2PKit.p2pkitCallbackHandler_[nativeCallback.methodName](nativeCallback.params);
-      }
-    }
-  )
+  static addListener(name, callback) {
+    P2PKit.p2pkitCallbackEmitter.addListener(name, callback);
+  }
 
-  static enable(appkey, p2pkitCallbackHandler) {
-    if (!p2pkitCallbackHandler) {
-      throw 'You must enable p2pkit with appropriate callbacks';
-    }
+  static removeListener(name, callback) {
+    P2PKit.p2pkitCallbackEmitter.removeListener(name, callback);
+  }
 
-    P2PKit.p2pkitCallbackHandler_ = p2pkitCallbackHandler;
-
+  static enable(appkey) {
     PPKReactBridge.enable(appkey);
   }
 
-  static disable(){
+  static disable() {
     PPKReactBridge.disable();
   }
 
-  static getMyPeerId(myPeerId){
+  static getMyPeerId(myPeerId) {
     PPKReactBridge.getMyPeerId();
   }
 
-  static startDiscovery(discoveryInfo, discoveryPowerMode){
+  static startDiscovery(discoveryInfo, discoveryPowerMode) {
     PPKReactBridge.startDiscovery(discoveryInfo, discoveryPowerMode);
   }
 
-  static stopDiscovery(){
+  static stopDiscovery() {
     PPKReactBridge.stopDiscovery();
   }
 
-  static enableProximityRanging(){
+  static enableProximityRanging() {
     PPKReactBridge.enableProximityRanging();
   }
 
-  static pushNewDiscoveryInfo(discoveryInfo){
+  static pushNewDiscoveryInfo(discoveryInfo) {
     PPKReactBridge.pushNewDiscoveryInfo(discoveryInfo);
   }
 

--- a/ios/PPKReactBridge.m
+++ b/ios/PPKReactBridge.m
@@ -244,7 +244,8 @@ RCT_EXPORT_METHOD(setDiscoveryPowerMode:(NSString*)discoveryPowerMode)  {
         [statusMessage setObject:name forKey:@"methodName"];
         if(params) [statusMessage setObject:params forKey:@"params"];
 
-        [self sendEventWithName:@"callback" body:statusMessage];
+        // [self sendEventWithName:@"callback" body:statusMessage];
+        [self sendEventWithName:name body:params];
     });
 }
 
@@ -270,8 +271,9 @@ RCT_EXPORT_METHOD(setDiscoveryPowerMode:(NSString*)discoveryPowerMode)  {
     [super stopObserving];
 }
 
-- (NSArray<NSString *> *)supportedEvents {
-    return @[@"callback"];
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"onEnabled", @"onException", @"onDisabled", @"onError", @"onDiscoveryStateChanged", @"onPeerDiscovered", @"onPeerLost", @"onProximityStrengthChanged", @"onGetMyPeerId", @"onGetDiscoveryPowerMode"];
 }
 
 -(void)dealloc {

--- a/ios/PPKReactBridge.m
+++ b/ios/PPKReactBridge.m
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(disable) {
     dispatch_async(dispatch_get_main_queue(), ^{
 
         [PPKController disable];
-        [self invokePluginResultWithMethodName:@"onDisabled" parms:nil];
+        [self invokePluginResultWithMethodName:@"onDisabled" params:nil];
     });
 }
 
@@ -64,7 +64,7 @@ RCT_EXPORT_METHOD(getMyPeerId)  {
             return;
         }
 
-        [self invokePluginResultWithMethodName:@"onGetMyPeerId" parms:@{@"myPeerId":[PPKController myPeerID]}];
+        [self invokePluginResultWithMethodName:@"onGetMyPeerId" params:@{@"myPeerId":[PPKController myPeerID]}];
     });
 }
 
@@ -167,7 +167,7 @@ RCT_EXPORT_METHOD(getDiscoveryPowerMode)  {
             return;
         }
 
-        [self invokePluginResultWithMethodName:@"onGetDiscoveryPowerMode" parms:@{@"discoveryPowerMode":@"NOT_AVAILABLE_ON_IOS"}];
+        [self invokePluginResultWithMethodName:@"onGetDiscoveryPowerMode" params:@{@"discoveryPowerMode":@"NOT_AVAILABLE_ON_IOS"}];
     });
 }
 
@@ -183,37 +183,37 @@ RCT_EXPORT_METHOD(setDiscoveryPowerMode:(NSString*)discoveryPowerMode)  {
 
 -(void)PPKControllerInitialized {
 
-    [self invokePluginResultWithMethodName:@"onEnabled" parms:nil];
+    [self invokePluginResultWithMethodName:@"onEnabled" params:nil];
 }
 
 -(void)PPKControllerFailedWithError:(PPKErrorCode)error {
 
-    [self invokePluginResultWithMethodName:@"onError" parms:@{@"platform":@"ios", @"errorCode":[NSNumber numberWithInt:error]}];
+    [self invokePluginResultWithMethodName:@"onError" params:@{@"platform":@"ios", @"errorCode":[NSNumber numberWithInt:error]}];
 }
 
 -(void)discoveryStateChanged:(PPKDiscoveryState)state {
 
-    [self invokePluginResultWithMethodName:@"onDiscoveryStateChanged" parms:@{@"platform":@"ios", @"state":[NSNumber numberWithInt:state]}];
+    [self invokePluginResultWithMethodName:@"onDiscoveryStateChanged" params:@{@"platform":@"ios", @"state":[NSNumber numberWithInt:state]}];
 }
 
 -(void)peerDiscovered:(PPKPeer *)peer {
 
-    [self invokePluginResultWithMethodName:@"onPeerDiscovered" parms:[self createDictionaryFromPeer:peer]];
+    [self invokePluginResultWithMethodName:@"onPeerDiscovered" params:[self createDictionaryFromPeer:peer]];
 }
 
 -(void)peerLost:(PPKPeer *)peer {
 
-    [self invokePluginResultWithMethodName:@"onPeerLost" parms:[self createDictionaryFromPeer:peer]];
+    [self invokePluginResultWithMethodName:@"onPeerLost" params:[self createDictionaryFromPeer:peer]];
 }
 
 -(void)discoveryInfoUpdatedForPeer:(PPKPeer *)peer {
 
-    [self invokePluginResultWithMethodName:@"onPeerUpdatedDiscoveryInfo" parms:[self createDictionaryFromPeer:peer]];
+    [self invokePluginResultWithMethodName:@"onPeerUpdatedDiscoveryInfo" params:[self createDictionaryFromPeer:peer]];
 }
 
 -(void)proximityStrengthChangedForPeer:(PPKPeer *)peer {
 
-    [self invokePluginResultWithMethodName:@"onProximityStrengthChanged" parms:[self createDictionaryFromPeer:peer]];
+    [self invokePluginResultWithMethodName:@"onProximityStrengthChanged" params:[self createDictionaryFromPeer:peer]];
 }
 
 #pragma mark - Helpers
@@ -224,10 +224,10 @@ RCT_EXPORT_METHOD(setDiscoveryPowerMode:(NSString*)discoveryPowerMode)  {
         return;
     }
 
-    [self invokePluginResultWithMethodName:@"onException" parms:@{@"platform":@"ios",@"message":errorString}];
+    [self invokePluginResultWithMethodName:@"onException" params:@{@"platform":@"ios",@"message":errorString}];
 }
 
--(void)invokePluginResultWithMethodName:(NSString*)name parms:(NSDictionary*)parms {
+-(void)invokePluginResultWithMethodName:(NSString*)name params:(NSDictionary*)params {
 
     dispatch_async(dispatch_get_main_queue(), ^{
 
@@ -242,7 +242,7 @@ RCT_EXPORT_METHOD(setDiscoveryPowerMode:(NSString*)discoveryPowerMode)  {
 
         NSMutableDictionary *statusMessage = [NSMutableDictionary new];
         [statusMessage setObject:name forKey:@"methodName"];
-        if(parms) [statusMessage setObject:parms forKey:@"parms"];
+        if(params) [statusMessage setObject:params forKey:@"params"];
 
         [self sendEventWithName:@"callback" body:statusMessage];
     });


### PR DESCRIPTION
This removes the need to pass a callback object to `p2pkit.enable` and instead allows using event listeners when needed.