### PR TITLE
[FIX] PPKReactBridge.getMyPeerId is not a function

### DIFF
--- a/android/src/main/java/ch/uepaa/p2pkit/reactnative/PPKReactBridgeModule.java
+++ b/android/src/main/java/ch/uepaa/p2pkit/reactnative/PPKReactBridgeModule.java
@@ -52,6 +52,7 @@ public class PPKReactBridgeModule extends ReactContextBaseJavaModule implements 
         }
     }
 
+    @ReactMethod
     private void getMyPeerId() {
 
         if (!P2PKit.isEnabled()) {


### PR DESCRIPTION
`p2pkit.getMyPeerId()` does not work as it is missing the **@ReactMethod** annotation to expose the method to JavaScript. According to react-native's docs (https://facebook.github.io/react-native/docs/native-modules-android), _to expose a method to JavaScript a Java method must be annotated using @ReactMethod_.



